### PR TITLE
Update secret name in README.md

### DIFF
--- a/data-logger/README.md
+++ b/data-logger/README.md
@@ -59,7 +59,7 @@ Create a secret for the InfluxDB user:
 ```bash
 export PASSWORD=""
 
-faas-cli secret create influx-password --from-literal $PASSWORD
+faas-cli secret create influx-pass --from-literal $PASSWORD
 faas-cli secret create influx-user --from-literal admin
 ```
 


### PR DESCRIPTION
When following the instructions in the README.md, the `deploy` operation failed due to a missing secret. 

```cli
$ faas-cli deploy
Deploying: submit-sample.
WARNING! You are not using an encrypted connection to the gateway, consider using HTTPS.

Unexpected status: 400, message: unable to find secret: influx-pass
unable to start task: submit-sample, error: OCI runtime create failed: container_linux.go:344: starting container process caused "process_linux.go:424: container init caused \"rootfs_linux.go:58: mounting \\\"/var/lib/faasd-provider/secrets/influx-pass\\\" to rootfs \\\"/run/containerd/io.containerd.runtime.v2.task/openfaas-fn/submit-sample/rootfs\\\" at \\\"/var/openfaas/secrets/influx-pass\\\" caused \\\"stat /var/lib/faasd-provider/secrets/influx-pass: no such file or directory\\\"\"": unknown
```

This is due to a different secret name being defined in the `stack.yml` file: https://github.com/alexellis/growlab/blob/master/data-logger/stack.yml#L20