### PR TITLE
:sparkles: Add DTH22 sensor support

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -19,6 +19,11 @@ See also: [app roadmap](https://github.com/alexellis/growlab/issues/15)
 ![How to connect the sensor over i2c](sensor-i2c.png)
 > How to connect the sensor over i2c
 
+For the DHT22 sensor, 
+* pin 1 of the sensor is connected to a 5V pin of the PI
+* pin 2 of the sensor is connected to a ground pin of the PI
+* pin 3 of the sensor is connected to the pin 7 (GPIO 4)
+
 ### Configuring the RPi
 
 Using `raspi-config`
@@ -127,6 +132,13 @@ If you have the BMP280, then run this instead:
 
 ```bash
 export SENSOR_TYPE=bmp280
+python3 app.py
+```
+
+If you have the DHT22, then run this instead:
+
+```bash
+export SENSOR_TYPE=DHT22
 python3 app.py
 ```
 

--- a/app/app.py
+++ b/app/app.py
@@ -2,7 +2,7 @@
 
 import json
 import os, sys
-from sensors import growbme280, growbmp280, grownosensor
+from sensors import growbme280, growbmp280, growdht22, grownosensor
 from camera import camera
 from specimen import specimen
 
@@ -25,6 +25,8 @@ if __name__ == "__main__":
         sensor = growbme280()
     if sensor_type == "bmp280":
         sensor = growbmp280()
+    if sensor_type == "DHT22":
+        sensor = growdht22()
     elif sensor_type == "none":
         sensor = grownosensor()
 

--- a/app/growlab.service
+++ b/app/growlab.service
@@ -13,7 +13,7 @@ RestartSec=600
 
 StartLimitInterval=0
 
-# Sensor type: "none", "BME280" or "BMP280"
+# Sensor type: "none", "BME280", "BMP280", or "DHT22"
 Environment="SENSOR_TYPE=BME280"
 WorkingDirectory=/home/pi/growlab/app
 ExecStart=/home/pi/growlab/app/sample.sh

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -4,3 +4,4 @@ bmp280
 picamera
 pillow
 Jinja2
+Adafruit_DHT

--- a/app/sensors.py
+++ b/app/sensors.py
@@ -5,6 +5,7 @@ except ImportError:
 from bme280 import BME280
 from bmp280 import BMP280
 
+import Adafruit_DHT
 import time
 
 class grownosensor:
@@ -61,4 +62,19 @@ class growbmp280:
             "time": time_str,
             "temperature": temperature,
             "pressure": pressure,
+        }
+
+class growdht22:
+    def __init__(self):
+        self.DHT_SENSOR = Adafruit_DHT.DHT22
+        self.DHT_PIN = 4
+
+    def get_readings(self):
+        humidity, temperature = Adafruit_DHT.read_retry(self.DHT_SENSOR, self.DHT_PIN)
+        time_str = time.strftime("%H:%M:%S")
+
+        return {
+            "time": time_str,
+            "temperature": temperature,
+            "humidity": humidity
         }


### PR DESCRIPTION
Add the DHT22 Sensor (temperature and humidity)

    Add a class in sensor.py
    Update the readme for the sensor connection
    Update the service

Nota: I think the type of sensor can be set via the config.json file instead of an environnement variable. @alexellis what do you think about it ?